### PR TITLE
Drone admin

### DIFF
--- a/drone-server/bin/functions.sh
+++ b/drone-server/bin/functions.sh
@@ -77,6 +77,7 @@ sc_config_check () {
   gitea_client_id=$(lucky get-config gitea-client-id)
   gitea_client_secret=$(lucky get-config gitea-client-secret)
   gitea_server=$(lucky get-config gitea-server)
+  admin=$(lucky get-config admin)
   server_host=$(lucky get-config server-host)
   server_proto=$(lucky get-config server-proto)
   tls_autocert=$(lucky get-config tls-autocert)

--- a/drone-server/config.yaml
+++ b/drone-server/config.yaml
@@ -56,6 +56,10 @@ options:
     type: string
     default: https
     description: Protocol under which your host or domain will be served publicly. (Either 'http' or 'https')
+  server-volume:
+    type: string
+    default:
+    description: Volume name or absolute path for Drone Server data persistence
   tls-autocert:
     type: boolean
     default: false

--- a/drone-server/config.yaml
+++ b/drone-server/config.yaml
@@ -44,6 +44,10 @@ options:
     type: string
     default:
     description: A Gitea Server Address
+  admin:
+    type: string
+    default:
+    description: Drone Admin user
   server-host:
     type: string
     default:

--- a/drone-server/host_scripts/update-config.sh
+++ b/drone-server/host_scripts/update-config.sh
@@ -45,6 +45,7 @@ lucky container env set \
     "DRONE_BITBUCKET_CLIENT_ID=${bitbucket_client_id}" \
     "DRONE_BITBUCKET_CLIENT_SECRET=${bitbucket_client_secret}" \
     "DRONE_RPC_SECRET=${rpc_secret}" \
+    "DRONE_USER_CREATE=username:${admin},admin:true" \
     "DRONE_SERVER_HOST=${server_host}" \
     "DRONE_SERVER_PROTO=${server_proto}" \
     "DRONE_TLS_AUTOCERT=${tls_autocert}"

--- a/drone-server/host_scripts/update-config.sh
+++ b/drone-server/host_scripts/update-config.sh
@@ -50,4 +50,11 @@ lucky container env set \
     "DRONE_SERVER_PROTO=${server_proto}" \
     "DRONE_TLS_AUTOCERT=${tls_autocert}"
 
+# If a volume name has been provided, create it
+drone_volume=$(lucky get-config server-volume)
+if [ -n ${drone_volume} ]; then
+    # Add a volume for Drone data
+    lucky container volume add ${drone_volume} /data
+fi
+
 lucky set-status -n config-status active


### PR DESCRIPTION
Added Admin option and Server Volume options. 

'admin' option takes a user account which will be made admin in the form of:
`DRONE_USER_CREATE=username:octocat,admin:true`
The "admin" user provided will placed where "octocat" is referenced above.

'server-volume' option allows operator to provide either a name or a path by which Lucky will provision a Lucky Container Volume using methods outlined [here](https://katharostech.github.io/lucky/cli/lucky/client/container/volume.html).